### PR TITLE
Config to turn off teleporter

### DIFF
--- a/js/adapt-teleporter.js
+++ b/js/adapt-teleporter.js
@@ -114,6 +114,10 @@ define(function(require) {
 		if (topZIndex !== 0 && topZIndex >= zIndex) $el.css("z-index", topZIndex + 1);
 	}
 
-	Adapt.on("app:dataReady", function() { if (!Adapt.device.touch) render(); });
+	Adapt.on("app:dataReady", function() { 
+		var config = Adapt.config.get('_teleporter');
+		if (!_.isUndefined(config) && config._isEnabled == false) return;
+		if (!Adapt.device.touch) render(); 
+	});
 
 });


### PR DESCRIPTION
Ability to turn off teleporter from the `config.json` level

```
"_teleporter":{
"_isEnabled":false
}
```
